### PR TITLE
BZ1862098 - remove etcd records

### DIFF
--- a/ocp4/ocp4-zonefile.db
+++ b/ocp4/ocp4-zonefile.db
@@ -34,14 +34,4 @@ master2.ocp4		IN	A	192.168.1.99
 worker0.ocp4		IN	A	192.168.1.11
 worker1.ocp4		IN	A	192.168.1.7
 ;
-; The ETCd cluster lives on the masters...so point these to the IP of the masters
-etcd-0.ocp4	IN	A	192.168.1.97
-etcd-1.ocp4	IN	A	192.168.1.98
-etcd-2.ocp4	IN	A	192.168.1.99
-;
-; The SRV records are IMPORTANT....make sure you get these right...note the trailing dot at the end...
-_etcd-server-ssl._tcp.ocp4	IN	SRV	0 10 2380 etcd-0.ocp4.example.com.
-_etcd-server-ssl._tcp.ocp4	IN	SRV	0 10 2380 etcd-1.ocp4.example.com.
-_etcd-server-ssl._tcp.ocp4	IN	SRV	0 10 2380 etcd-2.ocp4.example.com.
-;
 ;EOF


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1862098

Please check me:
- That bz requested to remove etcd from doc.
- I have a different bz, 1809630, that requests updates to
  doc regarding DNS.  I plan to slurp in the zonefile
  and reverse file into the docs.
- Therefore, 4.4 and later doc--and sample files--should
  not include the DNS records for etcd. That's a question
  disguised as a statement.